### PR TITLE
Update public API reference for current AI Studio endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# BHuman API Docs
+# BHuman AI Studio API Docs
 
 Last updated: June 2026.
 
-This repository is the public GitHub endpoint reference for the BHuman API. The
-canonical, latest docs live on the BHuman website:
+This repository is the public GitHub endpoint reference for the BHuman AI Studio
+API. The richer documentation lives on the BHuman website:
 
+- https://www.bhuman.ai/docs
 - https://www.bhuman.ai/docs/api
 
 The generated Swagger UI and OpenAPI schema are available here:
@@ -12,41 +13,36 @@ The generated Swagger UI and OpenAPI schema are available here:
 - https://studio.bhuman.ai/swagger-ui/
 - https://studio.bhuman.ai/swagger-ui/openapi.json
 
-Use the BHuman API with AI Studio templates, campaigns, generated videos, and
-store products.
+The live schema is `BHuman AI Studio API` version `0.2.0`.
 
-## Important note about older docs
+## Current product model
 
-Older help center articles, screenshots, and videos may mention "Easy Mode" and
-"Advanced Mode." Those terms describe an older product flow and should not be
-used for new setup.
+Older BHuman help articles and videos may mention "Easy Mode" and "Advanced
+Mode." Those terms describe an older product flow and should not be used for new
+setup.
 
 The current model is:
 
 1. Create or import an AI Studio video template.
-2. Define the variables that should change per recipient.
-3. Generate personalized videos through AI Studio, a campaign, or the API.
-4. Use callback URLs or polling endpoints to collect video, thumbnail, and GIF
-   assets.
-
-The `BackgroundConfig.mode` field shown later in this guide is still valid, but
-it only controls how a dynamic background is displayed (`basic`, `circle`, or
-`chroma`). It is unrelated to the old Easy Mode or Advanced Mode flow.
-
-## Common setup paths
+2. Define the variables that should change for each recipient.
+3. Generate personalized videos through an AI Studio campaign, integration, or
+   API request.
+4. Use callback URLs or polling endpoints to collect share links, MP4 files,
+   thumbnails, GIF previews, status, and failure details.
 
 Personalized videos can start from either source:
 
 1. **Recorded or uploaded base video in AI Studio**
-   - Record or upload a presenter video.
-   - Mark variables such as `first_name`, `company`, `product_name`, or `cta_url`.
-   - Use the API to pass recipient-specific values and optional assets.
+   - Record or upload the presenter video.
+   - Mark variables such as `first_name`, `company`, `product_name`, or
+     `cta_url`.
+   - Trigger personalized renders through a campaign or API request.
 
 2. **Generated presenter video from Speakeasy**
    - Generate the presenter and voice in Speakeasy.
-   - Import the result into AI Studio.
+   - Import the finished project into AI Studio.
    - Mark variables in AI Studio.
-   - Trigger personalized renders through campaign or template API calls.
+   - Trigger personalized renders through campaign or API calls.
 
 ## Authentication
 
@@ -72,7 +68,7 @@ Example cURL setup:
 export BHUMAN_API_KEY_ID="your_api_key_id"
 export BHUMAN_API_KEY_SECRET="your_api_key_secret"
 
-AUTH_HEADER=$(printf "%s:%s" "$BHUMAN_API_KEY_ID" "$BHUMAN_API_KEY_SECRET" | base64)
+export BHUMAN_BASIC_AUTH=$(printf "%s:%s" "$BHUMAN_API_KEY_ID" "$BHUMAN_API_KEY_SECRET" | base64)
 ```
 
 Python helper:
@@ -87,40 +83,41 @@ token = base64.b64encode(f"{api_key_id}:{api_key_secret}".encode()).decode()
 headers = {"Authorization": f"Basic {token}"}
 ```
 
-## IDs and URLs
-
-Most API calls require an AI Studio video instance ID, a campaign ID, or a
-generation ID.
-
-Examples:
-
-- Campaign URL: `https://app.bhuman.ai/campaign/generatedVideos/b3d2bfa8-fa75-49ed-9f8b-bb13452f49fd`
-- Instance URL: `https://app.bhuman.ai/instance/7d859e18-dc89-446f-9718-9533bb178a75`
-
-The final path segment is the ID:
-
-- Campaign ID: `b3d2bfa8-fa75-49ed-9f8b-bb13452f49fd`
-- Video instance ID: `7d859e18-dc89-446f-9718-9533bb178a75`
-
 ## Endpoint summary
+
+All AI Studio API endpoints below use this host:
+
+```text
+https://studio.bhuman.ai
+```
 
 | Method | Endpoint | Purpose |
 | :-- | :-- | :-- |
-| `GET` | `https://studio.bhuman.ai/api/ai_studio/video_instances` | List AI Studio video instances |
-| `GET` | `https://studio.bhuman.ai/api/ai_studio/video_instance` | Get one video instance |
-| `POST` | `https://studio.bhuman.ai/api/ai_studio/try_sample` | Generate videos from a video instance |
-| `POST` | `https://studio.bhuman.ai/api/ai_studio/pipeline/campaign` | Generate videos from a campaign |
-| `GET` | `https://studio.bhuman.ai/api/ai_studio/generated_video_by_video_instance_id` | List generated videos for an instance |
-| `GET` | `https://studio.bhuman.ai/api/ai_studio/generated_video_by_campaign_id` | List generated videos for a campaign |
-| `GET` | `https://studio.bhuman.ai/api/ai_studio/generated_video_by_id` | Get one generated video |
-| `GET` | `https://user.bhuman.ai/api/workspace` | Get workspace data |
-| `GET` | `https://store.bhuman.ai/api/store/product` | List store products |
-| `POST` | `https://store.bhuman.ai/api/store/product/use` | Use a store product |
-| `GET` | `https://store.bhuman.ai/api/store/settings` | Get store categories and tags |
+| `POST` | `/api/ai_studio/pipeline/campaign` | Generate campaign videos from ordered variables and recipient rows |
+| `POST` | `/api/ai_studio/pipeline/zapier` | Generate videos from the structured automation payload shape |
+| `POST` | `/api/ai_studio/pipeline/pabbly` | Generate videos from a simple object-style webhook payload |
+| `POST` | `/api/ai_studio/pipeline/leadr` | Generate videos from Leadr pipeline data |
+| `POST` | `/api/ai_studio/try_sample` | Generate videos directly from a video instance ID |
+| `GET` | `/api/ai_studio/video_instances` | List AI Studio video instances |
+| `GET` | `/api/ai_studio/video_instance?id={video_instance_id}` | Fetch one video instance |
+| `GET` | `/api/ai_studio/campaigns` | List campaigns |
+| `GET` | `/api/ai_studio/campaign?id={campaign_id}` | Fetch one campaign |
+| `GET` | `/api/ai_studio/generated_video_by_video_instance_id?video_instance_id={video_instance_id}` | List generated videos for an instance |
+| `GET` | `/api/ai_studio/generated_video_by_campaign_id?campaign_id={campaign_id}` | List generated videos for a campaign |
+| `GET` | `/api/ai_studio/generated_video_by_id?id={generation_id}` | Fetch one generated video |
+| `GET` | `/api/ai_studio/speakeasy_projects` | List Speakeasy projects available for import |
+| `POST` | `/api/ai_studio/speakeasy_projects/import` | Import a Speakeasy project into AI Studio |
+| `GET` | `/api/ai_studio/webhook` | List saved campaign webhooks |
+| `POST` | `/api/ai_studio/webhook` | Create a saved campaign webhook |
+| `POST` | `/api/ai_studio/videos_preview` | Create a video preview request |
+
+For exact optional fields and additional operations, use Swagger:
+
+- https://studio.bhuman.ai/swagger-ui/
 
 ## Generate videos from a campaign
 
-Use this endpoint when your workflow is based on a campaign.
+Use this endpoint when your workflow is based on an AI Studio campaign.
 
 ```http
 POST https://studio.bhuman.ai/api/ai_studio/pipeline/campaign
@@ -130,99 +127,90 @@ Request body:
 
 | Field | Type | Required | Notes |
 | :-- | :-- | :-- | :-- |
-| `campaign_id` | `Uuid` | Yes | Campaign ID |
+| `campaign_id` | `String` | Yes | Campaign ID |
 | `variables` | `String[]` | Yes | Variable names in the same order as each row in `names` |
 | `names` | `String[][]` | Yes | Recipient rows. Each row maps to `variables` by position |
-| `callback_url` | `String` | No | BHuman sends one callback per generated video |
-| `backgrounds` | `Background[]` | No | Dynamic background segments |
+| `callback_url` | `String` | No | BHuman sends completion details for generated videos |
 | `assets` | `String[][]` | No | Asset URL rows used by dynamic backgrounds |
+| `backgrounds` | `Background[]` | No | Dynamic background segments |
+| `enable_lipsync` | `Boolean` | No | Enable lip sync when supported by the template |
+| `enable_subtitles` | `Boolean` | No | Request subtitles when supported by the template |
 
 Example:
 
 ```bash
 curl -X POST "https://studio.bhuman.ai/api/ai_studio/pipeline/campaign" \
-  -H "Authorization: Basic $AUTH_HEADER" \
+  -H "Authorization: Basic $BHUMAN_BASIC_AUTH" \
   -H "Content-Type: application/json" \
   -d '{
-    "campaign_id": "d744af70-cd3c-4a41-8bfe-89238f937a3b",
-    "variables": ["first_name", "company"],
+    "campaign_id": "YOUR_CAMPAIGN_ID",
+    "variables": ["first_name", "company", "cta_url"],
     "names": [
-      ["Alex", "ExampleCo"],
-      ["Jordan", "Sample Labs"]
+      ["Alex", "ExampleCo", "https://example.com/start"],
+      ["Jordan", "Sample Labs", "https://example.com/book"]
     ],
-    "callback_url": "https://example.com/webhooks/bhuman"
+    "callback_url": "https://yourapp.com/bhuman/callback"
   }'
 ```
 
-Immediate response:
+Accepted response:
 
 ```json
 {
+  "code": 200,
   "result": [
     "c10ee155-6202-4cec-9a40-dde536e2ab4e"
   ]
 }
 ```
 
-If `callback_url` is provided, BHuman sends a `POST` callback for each
-generation.
+## Pabbly-style payload
 
-Callback payload:
+Use the Pabbly endpoint when a webhook builder is easier with object-style
+variables instead of ordered row arrays.
 
-| Field | Type | Notes |
-| :-- | :-- | :-- |
-| `id` | `Uuid` | Generation ID |
-| `status` | `String` | `succeeded`, `failed`, or `processing` |
-| `video_url` | `String` | Hosted playback URL |
-| `url` | `String` | Downloadable MP4 URL |
-| `thumbnail` | `String` | Downloadable thumbnail URL |
-| `gif` | `String` | Downloadable GIF URL |
+```http
+POST https://studio.bhuman.ai/api/ai_studio/pipeline/pabbly
+```
+
+Example:
+
+```json
+{
+  "campaign_id": "YOUR_CAMPAIGN_ID",
+  "variables": {
+    "first_name": "Alex",
+    "company": "ExampleCo",
+    "cta_url": "https://example.com/start"
+  },
+  "callback_url": "https://yourapp.com/bhuman/callback"
+}
+```
 
 ## Generate videos from a video instance
 
 Use this endpoint when your workflow targets a specific AI Studio video
-instance.
+instance instead of a campaign.
 
 ```http
 POST https://studio.bhuman.ai/api/ai_studio/try_sample
 ```
 
-Request body:
-
-| Field | Type | Required | Notes |
-| :-- | :-- | :-- | :-- |
-| `video_instance_id` | `Uuid` | Yes | AI Studio video instance ID |
-| `variables` | `String[]` | Yes | Variable names in the same order as each row in `names` |
-| `names` | `String[][]` | Yes | Recipient rows. Each row maps to `variables` by position |
-| `callback_url` | `String` | No | BHuman sends one callback per generated video |
-| `backgrounds` | `Background[]` | No | Dynamic background segments |
-| `assets` | `String[][]` | No | Asset URL rows used by dynamic backgrounds |
-
 Example:
 
 ```bash
 curl -X POST "https://studio.bhuman.ai/api/ai_studio/try_sample" \
-  -H "Authorization: Basic $AUTH_HEADER" \
+  -H "Authorization: Basic $BHUMAN_BASIC_AUTH" \
   -H "Content-Type: application/json" \
   -d '{
-    "video_instance_id": "7d859e18-dc89-446f-9718-9533bb178a75",
+    "video_instance_id": "YOUR_VIDEO_INSTANCE_ID",
     "variables": ["first_name", "company"],
     "names": [
       ["Alex", "ExampleCo"],
       ["Jordan", "Sample Labs"]
     ],
-    "callback_url": "https://example.com/webhooks/bhuman"
+    "callback_url": "https://yourapp.com/bhuman/callback"
   }'
-```
-
-Immediate response:
-
-```json
-{
-  "result": [
-    "c10ee155-6202-4cec-9a40-dde536e2ab4e"
-  ]
-}
 ```
 
 ## Variables and recipient rows
@@ -241,7 +229,7 @@ Example:
 }
 ```
 
-For a generic customer workflow, common variables are:
+Common variables:
 
 - `first_name`
 - `company`
@@ -250,11 +238,13 @@ For a generic customer workflow, common variables are:
 - `cta_url`
 - `booking_url`
 - `renewal_date`
+- `asset_url`
 
 ## Dynamic backgrounds
 
-Dynamic backgrounds let a generated video show a website, image, video, LinkedIn
-page, product page, landing page, or other URL behind or around the presenter.
+Dynamic backgrounds let a generated video show a website, image, video,
+LinkedIn page, product page, landing page, or other URL behind or around the
+presenter.
 
 `assets` is a row-by-row matrix. Each recipient row can provide one or more URLs
 used by the matching background segment.
@@ -274,7 +264,7 @@ Example:
   ],
   "backgrounds": [
     {
-      "name": "website",
+      "name": "product_page",
       "start": 0,
       "end": 3,
       "kind": "site",
@@ -285,7 +275,7 @@ Example:
       }
     },
     {
-      "name": "demo-video",
+      "name": "demo_video",
       "start": 3,
       "end": -1,
       "kind": "link",
@@ -305,138 +295,119 @@ Example:
 | `name` | `String` | No | Reference name for debugging |
 | `start` | `Number` | Yes | Segment start time in seconds |
 | `end` | `Number` | Yes | Segment end time in seconds. Use `-1` for the rest of the video |
-| `kind` | `String` | Yes | One of `link`, `site`, or `linkedin` |
+| `kind` | `String` | Yes | Common values include `link`, `site`, and `linkedin` |
 | `config` | `BackgroundConfig` | Yes | Display settings |
 
 ### BackgroundConfig
 
-| Field | Type | Default | Notes |
-| :-- | :-- | :-- | :-- |
-| `mode` | `String` | Required | Background display mode: `basic`, `circle`, or `chroma` |
-| `scale` | `Number` | `0.4` | Scale factor for the presenter overlay |
-| `position` | `String` | `bottom-right` | Overlay position, such as `center`, `bottom`, `bottom-left`, or `top-right` |
-| `audio` | `Boolean` | `false` | Whether to use audio from the background asset |
-| `brightness` | `Number` | `1` | Brightness for the non-covered background area |
-| `color` | `String` | `00FF00` | Chroma key color in HEX when using `chroma` |
-| `similarity` | `Number` | `0.1` | Similarity level when using `chroma` |
-| `blend` | `Number` | `0.1` | Blend level when using `chroma` |
+| Field | Type | Notes |
+| :-- | :-- | :-- |
+| `mode` | `String` | Background display mode, such as `circle` or `chroma` |
+| `scale` | `Number` | Scale factor for the presenter overlay |
+| `position` | `String` | Overlay position, such as `center`, `bottom-right`, or `top-right` |
+| `audio` | `Boolean` | Whether to use audio from the background asset |
+| `brightness` | `Number` | Brightness for the non-covered background area |
+| `color` | `String` | Chroma key color in HEX when using `chroma` |
+| `similarity` | `Number` | Similarity level when using `chroma` |
+| `blend` | `Number` | Blend level when using `chroma` |
 
-## Poll generated videos
+## Completion callbacks and polling
 
-If you do not provide `callback_url`, poll the generated video endpoints.
+If `callback_url` is provided, BHuman can send completion details for generated
+videos. Store the generation ID so callbacks and polling responses can be
+reconciled.
 
-### By video instance ID
-
-```http
-GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_video_instance_id?video_instance_id={video_instance_id}&page=0&size=100
-```
-
-### By campaign ID
-
-```http
-GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_campaign_id?campaign_id={campaign_id}&page=0&size=100
-```
-
-### By generation ID
-
-```http
-GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_id?id={generation_id}
-```
-
-Generated video response fields:
+Completion fields:
 
 | Field | Type | Notes |
 | :-- | :-- | :-- |
-| `id` | `Uuid` | Generation ID |
-| `user_id` | `String` | User ID |
-| `video_id` | `Uuid` | Video ID |
-| `actor_id` | `Uuid` | Actor ID |
-| `video_instance_id` | `Uuid` | Present when generated from an instance |
-| `campaign_id` | `Uuid` | Present when generated from a campaign |
+| `id` | `String` | Generation ID |
+| `status` | `String` | Processing, succeeded, failed, or related render state |
+| `share_url` | `String` | Hosted video page or share destination when available |
 | `url` | `String` | Downloadable MP4 URL |
-| `vimeo_url` | `String` | Hosted playback URL |
-| `thumbnail` | `String` | Thumbnail URL |
-| `gif` | `String` | GIF URL |
-| `status` | `String` | Generation status |
-| `execution_name` | `String` | Execution ID to share with support if generation fails |
-| `row_index` | `Int` | Row index from the submitted `names` payload |
-| `text` | `String[]` | Submitted variable values for that row |
-| `message` | `String` | Failure or status message when available |
-| `created_at` | `Datetime` | Creation timestamp |
-| `updated_at` | `Datetime` | Update timestamp |
+| `thumbnail` | `String` | Generated thumbnail image URL |
+| `gif` | `String` | Generated GIF preview URL |
+| `message` | `String` | Failure or processing detail when available |
+| `execution_name` | `String` | Pipeline execution identifier when available |
+| `row_index` | `Int` | Recipient row index when available |
 
-## Video instances
+Example:
 
-### List video instances
-
-```http
-GET https://studio.bhuman.ai/api/ai_studio/video_instances?page=0&size=100
+```json
+{
+  "id": "c10ee155-6202-4cec-9a40-dde536e2ab4e",
+  "status": "succeeded",
+  "share_url": "https://videos.bhuman.ai/video/...",
+  "url": "https://assets.bhuman.ai/generated-video.mp4",
+  "thumbnail": "https://assets.bhuman.ai/thumb.jpg",
+  "gif": "https://assets.bhuman.ai/preview.gif"
+}
 ```
 
-Parameters:
-
-| Field | Type | Required | Notes |
-| :-- | :-- | :-- | :-- |
-| `page` | `Int` | Yes | Starts at `0` |
-| `size` | `Int` | Yes | Maximum `100` |
-
-### Get one video instance
+If you do not use callbacks, poll generated video endpoints:
 
 ```http
-GET https://studio.bhuman.ai/api/ai_studio/video_instance?id={video_instance_id}
+GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_video_instance_id?video_instance_id={video_instance_id}&page=0&size=100
+GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_campaign_id?campaign_id={campaign_id}&page=0&size=100
+GET https://studio.bhuman.ai/api/ai_studio/generated_video_by_id?id={generation_id}
 ```
 
-## Workspace
+## Speakeasy imports
+
+Use Speakeasy to generate the presenter and voice, then import that project into
+AI Studio before marking variables or triggering campaign/API rendering.
+
+List importable projects:
 
 ```http
-GET https://user.bhuman.ai/api/workspace
+GET https://studio.bhuman.ai/api/ai_studio/speakeasy_projects
 ```
 
-Optional query parameter:
+Import a project:
 
-| Field | Type | Required | Notes |
-| :-- | :-- | :-- | :-- |
-| `id` | `Uuid` | No | Workspace ID |
-
-## Store products
-
-### List products
-
-```http
-GET https://store.bhuman.ai/api/store/product
+```bash
+curl -X POST "https://studio.bhuman.ai/api/ai_studio/speakeasy_projects/import" \
+  -H "Authorization: Basic $BHUMAN_BASIC_AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project_id": "SPEAKEASY_PROJECT_ID",
+    "workspace_id": "OPTIONAL_WORKSPACE_ID"
+  }'
 ```
 
-### Use a product
+## Saved webhooks
+
+Create a reusable webhook destination:
 
 ```http
-POST https://store.bhuman.ai/api/store/product/use
+POST https://studio.bhuman.ai/api/ai_studio/webhook
 ```
 
 Request body:
 
-| Field | Type | Required | Notes |
-| :-- | :-- | :-- | :-- |
-| `id` | `Uuid` | Yes | Product ID |
-| `workspace_id` | `Uuid` | Yes | Workspace ID |
-| `folder_id` | `Uuid` | No | Existing folder ID |
-| `video_instance_id` | `Uuid` | No | Existing video instance ID |
-
-If `folder_id` and `video_instance_id` are omitted, BHuman creates a new folder
-and video instance.
-
-If `video_instance_id` is provided, `folder_id` must also be provided.
-
-### Categories and tags
-
-```http
-GET https://store.bhuman.ai/api/store/settings
+```json
+{
+  "name": "Production callback",
+  "webhook": "https://yourapp.com/bhuman/callback"
+}
 ```
 
-## PHP SDK
+List saved webhooks:
 
-Community PHP SDK:
+```http
+GET https://studio.bhuman.ai/api/ai_studio/webhook
+```
 
-- https://github.com/henryreith/BHuman-PHP-SDK
+## Production checklist
+
+- Use HTTPS callback URLs that can accept repeated delivery attempts.
+- Store generation IDs so callbacks and polling responses can be reconciled.
+- Keep variables stable after a campaign is wired into a production workflow.
+- Send row-specific assets in the same order as recipient rows.
+- Treat generated media URLs as outputs from an async render job, not as
+  immediate inline responses.
+- Check Swagger before launching custom integrations that rely on optional
+  fields.
 
 ## Support
 
@@ -445,4 +416,4 @@ For API support, contact help@bhuman.ai.
 Helpful links:
 
 - API docs: https://www.bhuman.ai/docs/api
-- Help center: https://help.bhuman.ai
+- Swagger UI: https://studio.bhuman.ai/swagger-ui/


### PR DESCRIPTION
## Summary
- Refresh README around the current BHuman AI Studio API and Swagger/OpenAPI 0.2.0
- Add current pipeline, Pabbly, Zapier, Leadr, try_sample, generated-video polling, Speakeasy import, and webhook endpoint groups
- Remove stale store-product references and help-center handoff
- Replace older video_url wording with current share_url/url/thumbnail/gif output fields
- Keep examples generic rather than vertical-specific

## Verification
- Compared endpoint groups against https://studio.bhuman.ai/swagger-ui/openapi.json
- Scanned README for help-center links, real-estate examples, private names, and old video_url field