### PR TITLE
Remove legacy mode labels from public API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The live schema is `BHuman AI Studio API` version `0.2.0`.
 
 ## Current product model
 
-Older BHuman help articles and videos may mention "Easy Mode" and "Advanced
-Mode." Those terms describe an older product flow and should not be used for new
-setup.
+Older BHuman articles and videos may use legacy setup terminology. New work
+should use AI Studio templates, campaigns, variables, Speakeasy imports, API
+generation, callbacks, and generated assets.
 
 The current model is:
 


### PR DESCRIPTION
## Summary\n- Replace literal legacy mode labels with neutral legacy-terminology wording\n- Keeps the public API README focused on AI Studio templates, campaigns, variables, Speakeasy imports, callbacks, and generated assets\n\n## Validation\n- stale-phrase scan clean for old mode labels, Help Center links, old video_url, and customer-specific examples